### PR TITLE
Fix display out of various linux distros

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-oneplus-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-oneplus-common.dtsi
@@ -23,7 +23,6 @@
 	};
 
 	chosen {
-		stdout-path = "serial0:115200n8";
 	};
 
 	gpio-keys {


### PR DESCRIPTION
Also plymouth bootscreen works now